### PR TITLE
Change to be a SWC Lesson

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -12,13 +12,16 @@ carpentry: "swc"
 # Overall title for pages.
 title: "More Modern CMake"
 
+# Life cycle stage of the lesson
+# possible values: "pre-alpha", "alpha", "beta", "stable"
+life_cycle: "pre-alpha"
 
 #------------------------------------------------------------
 # Generic settings (should not need to change).
 #------------------------------------------------------------
 
 # What kind of thing is this ("workshop" or "lesson")?
-kind: "workshop"
+kind: "lesson"
 
 # Magic to make URLs resolve both locally and on GitHub.
 # See https://help.github.com/articles/repository-metadata-on-github-pages/.

--- a/_episodes/06-projectstructure.md
+++ b/_episodes/06-projectstructure.md
@@ -1,0 +1,62 @@
+---
+title: "Project Structure"
+teaching: 0
+exercises: 0
+questions:
+- "What is CMake?"
+objectives:
+- "Understand why CMake is used"
+- "Understand that CMake is not Make"
+keypoints:
+- "CMake is a build system generator"
+---
+
+Building code is hard. You need long commands to build each part of your code; and you need do to this on many parts of your code.
+
+So people came up with **Build Systems**; these had ways set up dependencies (such as file A needs to be built to build file B), and ways to store the commands used to build each file or type of file. These are language independent (mostly), allowing you to setup builds of almost anything; you can use `make` to build LaTeX documents if you wish. Some common build systems include make (the classic pervasive one), ninja (a newer one from Google designed in the age of build system generators), and rake (Ruby make, nice syntax for Ruby users).
+
+However, this is:
+
+* Mostly hand coded: You have to know all the proper commands
+* Platform/compiler dependent: You have to build the commands for each compiler.
+* Not aware of dependencies: If you require a library, you have to handle the paths, etc.
+* Hard to extend; if you want to use an IDE instead, good luck.
+
+Enter **Build System Generators** (hereby labeled BSGs for brevity). These understand the concepts of your programming language build; they usually support common compilers, languages, libraries, and output formats. These usually write a build system (or IDE) file and then let that do the actually build. The most popular BSG is CMake, which stands for Cross-platform Make. But as we've just shown, it is not really in the same category as make. Other BSGs include Meson (by Google), SCons (older Python system), Meson (very young Python system), and a few others. But CMake has unparalleled support by IDEs, libraries, and compilers.
+
+Note that both CMake and Make are custom languages rather than being built in an existing language, like rake and SCons, etc. While it is nice to consolidate languages, the requirement that you have an external language installed and configured was too high for any of these to catch on for general use.
+
+To recap, you should use CMake if:
+
+* You want to avoid hard-coding paths
+* You need to build a package on more than one computer
+* You want to use CI (continuous integration)
+* You need to support different OSs (maybe even just flavors of Unix)
+* You want to support multiple compilers
+* You want to use an IDE, but maybe not all of the time
+* You want to describe how your program is structured logically, not flags and commands
+* You want to use a library
+* You want to use tools, like Clang-Tidy, to help you code
+* You want to use a debugger
+
+
+## (More) Modern CMake
+
+CMake has really changed dramatically since it was introduced around 2000. And, by the time of 2.8, it was available in lots of Linux Distribution package managers. However, this means there often are really old versions of CMake "available by default" in your environment. Please, please upgrade and design for newer CMake. No one likes writing or debugging build systems[^1]. Using a newer version can cut your build system code in less than half, reduce bugs, integrate better with external dependants, and more. Installing CMake can be as little as one line, and doesn't require sudo access. [See more info here](https://cliutils.gitlab.io/modern-cmake/chapters/intro/installing.html).
+
+## Other sources
+
+There are some other places to find good information on the web. Here are some of them:
+
+* [Modern CMake][]: The book this tutorial derives from.
+* [The official help](https://cmake.org/cmake/help/latest/): Really amazing documentation. Nicely organized, great search, and you can toggle versions at the top. It just doesn't have a great "best practices tutorial", which is what this book tries to fill in.
+* [Effective Modern CMake](https://gist.github.com/mbinna/c61dbb39bca0e4fb7d1f73b0d66a4fd1): A great list of do's and don'ts.
+* [Embracing Modern CMake](https://steveire.wordpress.com/2017/11/05/embracing-modern-cmake/): A post with good description of the term
+* [It's time to do CMake Right](https://pabloariasal.github.io/2018/02/19/its-time-to-do-cmake-right/): A nice set of best practices for Modern CMake projects.
+* [The Ultimate Guide to Modern CMake](https://rix0r.nl/blog/2015/08/13/cmake-guide/): A slightly dated post with similar intent.
+* [More Modern CMake](https://youtu.be/y7ndUhdQuU8): A great presentation from Meeting C++ 2018 that recommends CMake 3.12+. This talk makes calls CMake 3.0+ "Modern CMake" and CMake 3.12+ "More Modern CMake".
+* [toeb/moderncmake](https://github.com/toeb/moderncmake): A nice presentation and examples about CMake 3.5+, with intro to syntax through project organization
+
+[Modern CMake]: https://cliutils.gitlab.io/modern-cmake/
+
+{% include links.md %}

--- a/_episodes/07-commonproblems.md
+++ b/_episodes/07-commonproblems.md
@@ -1,0 +1,62 @@
+---
+title: "Common Problems and Solutions"
+teaching: 0
+exercises: 0
+questions:
+- "What is CMake?"
+objectives:
+- "Understand why CMake is used"
+- "Understand that CMake is not Make"
+keypoints:
+- "CMake is a build system generator"
+---
+
+Building code is hard. You need long commands to build each part of your code; and you need do to this on many parts of your code.
+
+So people came up with **Build Systems**; these had ways set up dependencies (such as file A needs to be built to build file B), and ways to store the commands used to build each file or type of file. These are language independent (mostly), allowing you to setup builds of almost anything; you can use `make` to build LaTeX documents if you wish. Some common build systems include make (the classic pervasive one), ninja (a newer one from Google designed in the age of build system generators), and rake (Ruby make, nice syntax for Ruby users).
+
+However, this is:
+
+* Mostly hand coded: You have to know all the proper commands
+* Platform/compiler dependent: You have to build the commands for each compiler.
+* Not aware of dependencies: If you require a library, you have to handle the paths, etc.
+* Hard to extend; if you want to use an IDE instead, good luck.
+
+Enter **Build System Generators** (hereby labeled BSGs for brevity). These understand the concepts of your programming language build; they usually support common compilers, languages, libraries, and output formats. These usually write a build system (or IDE) file and then let that do the actually build. The most popular BSG is CMake, which stands for Cross-platform Make. But as we've just shown, it is not really in the same category as make. Other BSGs include Meson (by Google), SCons (older Python system), Meson (very young Python system), and a few others. But CMake has unparalleled support by IDEs, libraries, and compilers.
+
+Note that both CMake and Make are custom languages rather than being built in an existing language, like rake and SCons, etc. While it is nice to consolidate languages, the requirement that you have an external language installed and configured was too high for any of these to catch on for general use.
+
+To recap, you should use CMake if:
+
+* You want to avoid hard-coding paths
+* You need to build a package on more than one computer
+* You want to use CI (continuous integration)
+* You need to support different OSs (maybe even just flavors of Unix)
+* You want to support multiple compilers
+* You want to use an IDE, but maybe not all of the time
+* You want to describe how your program is structured logically, not flags and commands
+* You want to use a library
+* You want to use tools, like Clang-Tidy, to help you code
+* You want to use a debugger
+
+
+## (More) Modern CMake
+
+CMake has really changed dramatically since it was introduced around 2000. And, by the time of 2.8, it was available in lots of Linux Distribution package managers. However, this means there often are really old versions of CMake "available by default" in your environment. Please, please upgrade and design for newer CMake. No one likes writing or debugging build systems[^1]. Using a newer version can cut your build system code in less than half, reduce bugs, integrate better with external dependants, and more. Installing CMake can be as little as one line, and doesn't require sudo access. [See more info here](https://cliutils.gitlab.io/modern-cmake/chapters/intro/installing.html).
+
+## Other sources
+
+There are some other places to find good information on the web. Here are some of them:
+
+* [Modern CMake][]: The book this tutorial derives from.
+* [The official help](https://cmake.org/cmake/help/latest/): Really amazing documentation. Nicely organized, great search, and you can toggle versions at the top. It just doesn't have a great "best practices tutorial", which is what this book tries to fill in.
+* [Effective Modern CMake](https://gist.github.com/mbinna/c61dbb39bca0e4fb7d1f73b0d66a4fd1): A great list of do's and don'ts.
+* [Embracing Modern CMake](https://steveire.wordpress.com/2017/11/05/embracing-modern-cmake/): A post with good description of the term
+* [It's time to do CMake Right](https://pabloariasal.github.io/2018/02/19/its-time-to-do-cmake-right/): A nice set of best practices for Modern CMake projects.
+* [The Ultimate Guide to Modern CMake](https://rix0r.nl/blog/2015/08/13/cmake-guide/): A slightly dated post with similar intent.
+* [More Modern CMake](https://youtu.be/y7ndUhdQuU8): A great presentation from Meeting C++ 2018 that recommends CMake 3.12+. This talk makes calls CMake 3.0+ "Modern CMake" and CMake 3.12+ "More Modern CMake".
+* [toeb/moderncmake](https://github.com/toeb/moderncmake): A nice presentation and examples about CMake 3.5+, with intro to syntax through project organization
+
+[Modern CMake]: https://cliutils.gitlab.io/modern-cmake/
+
+{% include links.md %}

--- a/_episodes/08-debugging.md
+++ b/_episodes/08-debugging.md
@@ -1,0 +1,62 @@
+---
+title: "Debugging"
+teaching: 0
+exercises: 0
+questions:
+- "What is CMake?"
+objectives:
+- "Understand why CMake is used"
+- "Understand that CMake is not Make"
+keypoints:
+- "CMake is a build system generator"
+---
+
+Building code is hard. You need long commands to build each part of your code; and you need do to this on many parts of your code.
+
+So people came up with **Build Systems**; these had ways set up dependencies (such as file A needs to be built to build file B), and ways to store the commands used to build each file or type of file. These are language independent (mostly), allowing you to setup builds of almost anything; you can use `make` to build LaTeX documents if you wish. Some common build systems include make (the classic pervasive one), ninja (a newer one from Google designed in the age of build system generators), and rake (Ruby make, nice syntax for Ruby users).
+
+However, this is:
+
+* Mostly hand coded: You have to know all the proper commands
+* Platform/compiler dependent: You have to build the commands for each compiler.
+* Not aware of dependencies: If you require a library, you have to handle the paths, etc.
+* Hard to extend; if you want to use an IDE instead, good luck.
+
+Enter **Build System Generators** (hereby labeled BSGs for brevity). These understand the concepts of your programming language build; they usually support common compilers, languages, libraries, and output formats. These usually write a build system (or IDE) file and then let that do the actually build. The most popular BSG is CMake, which stands for Cross-platform Make. But as we've just shown, it is not really in the same category as make. Other BSGs include Meson (by Google), SCons (older Python system), Meson (very young Python system), and a few others. But CMake has unparalleled support by IDEs, libraries, and compilers.
+
+Note that both CMake and Make are custom languages rather than being built in an existing language, like rake and SCons, etc. While it is nice to consolidate languages, the requirement that you have an external language installed and configured was too high for any of these to catch on for general use.
+
+To recap, you should use CMake if:
+
+* You want to avoid hard-coding paths
+* You need to build a package on more than one computer
+* You want to use CI (continuous integration)
+* You need to support different OSs (maybe even just flavors of Unix)
+* You want to support multiple compilers
+* You want to use an IDE, but maybe not all of the time
+* You want to describe how your program is structured logically, not flags and commands
+* You want to use a library
+* You want to use tools, like Clang-Tidy, to help you code
+* You want to use a debugger
+
+
+## (More) Modern CMake
+
+CMake has really changed dramatically since it was introduced around 2000. And, by the time of 2.8, it was available in lots of Linux Distribution package managers. However, this means there often are really old versions of CMake "available by default" in your environment. Please, please upgrade and design for newer CMake. No one likes writing or debugging build systems[^1]. Using a newer version can cut your build system code in less than half, reduce bugs, integrate better with external dependants, and more. Installing CMake can be as little as one line, and doesn't require sudo access. [See more info here](https://cliutils.gitlab.io/modern-cmake/chapters/intro/installing.html).
+
+## Other sources
+
+There are some other places to find good information on the web. Here are some of them:
+
+* [Modern CMake][]: The book this tutorial derives from.
+* [The official help](https://cmake.org/cmake/help/latest/): Really amazing documentation. Nicely organized, great search, and you can toggle versions at the top. It just doesn't have a great "best practices tutorial", which is what this book tries to fill in.
+* [Effective Modern CMake](https://gist.github.com/mbinna/c61dbb39bca0e4fb7d1f73b0d66a4fd1): A great list of do's and don'ts.
+* [Embracing Modern CMake](https://steveire.wordpress.com/2017/11/05/embracing-modern-cmake/): A post with good description of the term
+* [It's time to do CMake Right](https://pabloariasal.github.io/2018/02/19/its-time-to-do-cmake-right/): A nice set of best practices for Modern CMake projects.
+* [The Ultimate Guide to Modern CMake](https://rix0r.nl/blog/2015/08/13/cmake-guide/): A slightly dated post with similar intent.
+* [More Modern CMake](https://youtu.be/y7ndUhdQuU8): A great presentation from Meeting C++ 2018 that recommends CMake 3.12+. This talk makes calls CMake 3.0+ "Modern CMake" and CMake 3.12+ "More Modern CMake".
+* [toeb/moderncmake](https://github.com/toeb/moderncmake): A nice presentation and examples about CMake 3.5+, with intro to syntax through project organization
+
+[Modern CMake]: https://cliutils.gitlab.io/modern-cmake/
+
+{% include links.md %}

--- a/_episodes/09-findingpackages.md
+++ b/_episodes/09-findingpackages.md
@@ -1,0 +1,62 @@
+---
+title: "Finding Packages"
+teaching: 0
+exercises: 0
+questions:
+- "What is CMake?"
+objectives:
+- "Understand why CMake is used"
+- "Understand that CMake is not Make"
+keypoints:
+- "CMake is a build system generator"
+---
+
+Building code is hard. You need long commands to build each part of your code; and you need do to this on many parts of your code.
+
+So people came up with **Build Systems**; these had ways set up dependencies (such as file A needs to be built to build file B), and ways to store the commands used to build each file or type of file. These are language independent (mostly), allowing you to setup builds of almost anything; you can use `make` to build LaTeX documents if you wish. Some common build systems include make (the classic pervasive one), ninja (a newer one from Google designed in the age of build system generators), and rake (Ruby make, nice syntax for Ruby users).
+
+However, this is:
+
+* Mostly hand coded: You have to know all the proper commands
+* Platform/compiler dependent: You have to build the commands for each compiler.
+* Not aware of dependencies: If you require a library, you have to handle the paths, etc.
+* Hard to extend; if you want to use an IDE instead, good luck.
+
+Enter **Build System Generators** (hereby labeled BSGs for brevity). These understand the concepts of your programming language build; they usually support common compilers, languages, libraries, and output formats. These usually write a build system (or IDE) file and then let that do the actually build. The most popular BSG is CMake, which stands for Cross-platform Make. But as we've just shown, it is not really in the same category as make. Other BSGs include Meson (by Google), SCons (older Python system), Meson (very young Python system), and a few others. But CMake has unparalleled support by IDEs, libraries, and compilers.
+
+Note that both CMake and Make are custom languages rather than being built in an existing language, like rake and SCons, etc. While it is nice to consolidate languages, the requirement that you have an external language installed and configured was too high for any of these to catch on for general use.
+
+To recap, you should use CMake if:
+
+* You want to avoid hard-coding paths
+* You need to build a package on more than one computer
+* You want to use CI (continuous integration)
+* You need to support different OSs (maybe even just flavors of Unix)
+* You want to support multiple compilers
+* You want to use an IDE, but maybe not all of the time
+* You want to describe how your program is structured logically, not flags and commands
+* You want to use a library
+* You want to use tools, like Clang-Tidy, to help you code
+* You want to use a debugger
+
+
+## (More) Modern CMake
+
+CMake has really changed dramatically since it was introduced around 2000. And, by the time of 2.8, it was available in lots of Linux Distribution package managers. However, this means there often are really old versions of CMake "available by default" in your environment. Please, please upgrade and design for newer CMake. No one likes writing or debugging build systems[^1]. Using a newer version can cut your build system code in less than half, reduce bugs, integrate better with external dependants, and more. Installing CMake can be as little as one line, and doesn't require sudo access. [See more info here](https://cliutils.gitlab.io/modern-cmake/chapters/intro/installing.html).
+
+## Other sources
+
+There are some other places to find good information on the web. Here are some of them:
+
+* [Modern CMake][]: The book this tutorial derives from.
+* [The official help](https://cmake.org/cmake/help/latest/): Really amazing documentation. Nicely organized, great search, and you can toggle versions at the top. It just doesn't have a great "best practices tutorial", which is what this book tries to fill in.
+* [Effective Modern CMake](https://gist.github.com/mbinna/c61dbb39bca0e4fb7d1f73b0d66a4fd1): A great list of do's and don'ts.
+* [Embracing Modern CMake](https://steveire.wordpress.com/2017/11/05/embracing-modern-cmake/): A post with good description of the term
+* [It's time to do CMake Right](https://pabloariasal.github.io/2018/02/19/its-time-to-do-cmake-right/): A nice set of best practices for Modern CMake projects.
+* [The Ultimate Guide to Modern CMake](https://rix0r.nl/blog/2015/08/13/cmake-guide/): A slightly dated post with similar intent.
+* [More Modern CMake](https://youtu.be/y7ndUhdQuU8): A great presentation from Meeting C++ 2018 that recommends CMake 3.12+. This talk makes calls CMake 3.0+ "Modern CMake" and CMake 3.12+ "More Modern CMake".
+* [toeb/moderncmake](https://github.com/toeb/moderncmake): A nice presentation and examples about CMake 3.5+, with intro to syntax through project organization
+
+[Modern CMake]: https://cliutils.gitlab.io/modern-cmake/
+
+{% include links.md %}

--- a/_episodes/10-root.md
+++ b/_episodes/10-root.md
@@ -1,0 +1,62 @@
+---
+title: "ROOT"
+teaching: 0
+exercises: 0
+questions:
+- "What is CMake?"
+objectives:
+- "Understand why CMake is used"
+- "Understand that CMake is not Make"
+keypoints:
+- "CMake is a build system generator"
+---
+
+Building code is hard. You need long commands to build each part of your code; and you need do to this on many parts of your code.
+
+So people came up with **Build Systems**; these had ways set up dependencies (such as file A needs to be built to build file B), and ways to store the commands used to build each file or type of file. These are language independent (mostly), allowing you to setup builds of almost anything; you can use `make` to build LaTeX documents if you wish. Some common build systems include make (the classic pervasive one), ninja (a newer one from Google designed in the age of build system generators), and rake (Ruby make, nice syntax for Ruby users).
+
+However, this is:
+
+* Mostly hand coded: You have to know all the proper commands
+* Platform/compiler dependent: You have to build the commands for each compiler.
+* Not aware of dependencies: If you require a library, you have to handle the paths, etc.
+* Hard to extend; if you want to use an IDE instead, good luck.
+
+Enter **Build System Generators** (hereby labeled BSGs for brevity). These understand the concepts of your programming language build; they usually support common compilers, languages, libraries, and output formats. These usually write a build system (or IDE) file and then let that do the actually build. The most popular BSG is CMake, which stands for Cross-platform Make. But as we've just shown, it is not really in the same category as make. Other BSGs include Meson (by Google), SCons (older Python system), Meson (very young Python system), and a few others. But CMake has unparalleled support by IDEs, libraries, and compilers.
+
+Note that both CMake and Make are custom languages rather than being built in an existing language, like rake and SCons, etc. While it is nice to consolidate languages, the requirement that you have an external language installed and configured was too high for any of these to catch on for general use.
+
+To recap, you should use CMake if:
+
+* You want to avoid hard-coding paths
+* You need to build a package on more than one computer
+* You want to use CI (continuous integration)
+* You need to support different OSs (maybe even just flavors of Unix)
+* You want to support multiple compilers
+* You want to use an IDE, but maybe not all of the time
+* You want to describe how your program is structured logically, not flags and commands
+* You want to use a library
+* You want to use tools, like Clang-Tidy, to help you code
+* You want to use a debugger
+
+
+## (More) Modern CMake
+
+CMake has really changed dramatically since it was introduced around 2000. And, by the time of 2.8, it was available in lots of Linux Distribution package managers. However, this means there often are really old versions of CMake "available by default" in your environment. Please, please upgrade and design for newer CMake. No one likes writing or debugging build systems[^1]. Using a newer version can cut your build system code in less than half, reduce bugs, integrate better with external dependants, and more. Installing CMake can be as little as one line, and doesn't require sudo access. [See more info here](https://cliutils.gitlab.io/modern-cmake/chapters/intro/installing.html).
+
+## Other sources
+
+There are some other places to find good information on the web. Here are some of them:
+
+* [Modern CMake][]: The book this tutorial derives from.
+* [The official help](https://cmake.org/cmake/help/latest/): Really amazing documentation. Nicely organized, great search, and you can toggle versions at the top. It just doesn't have a great "best practices tutorial", which is what this book tries to fill in.
+* [Effective Modern CMake](https://gist.github.com/mbinna/c61dbb39bca0e4fb7d1f73b0d66a4fd1): A great list of do's and don'ts.
+* [Embracing Modern CMake](https://steveire.wordpress.com/2017/11/05/embracing-modern-cmake/): A post with good description of the term
+* [It's time to do CMake Right](https://pabloariasal.github.io/2018/02/19/its-time-to-do-cmake-right/): A nice set of best practices for Modern CMake projects.
+* [The Ultimate Guide to Modern CMake](https://rix0r.nl/blog/2015/08/13/cmake-guide/): A slightly dated post with similar intent.
+* [More Modern CMake](https://youtu.be/y7ndUhdQuU8): A great presentation from Meeting C++ 2018 that recommends CMake 3.12+. This talk makes calls CMake 3.0+ "Modern CMake" and CMake 3.12+ "More Modern CMake".
+* [toeb/moderncmake](https://github.com/toeb/moderncmake): A nice presentation and examples about CMake 3.5+, with intro to syntax through project organization
+
+[Modern CMake]: https://cliutils.gitlab.io/modern-cmake/
+
+{% include links.md %}

--- a/_episodes/11-installing.md
+++ b/_episodes/11-installing.md
@@ -1,0 +1,62 @@
+---
+title: "BONUS! : Installing a Package"
+teaching: 0
+exercises: 0
+questions:
+- "What is CMake?"
+objectives:
+- "Understand why CMake is used"
+- "Understand that CMake is not Make"
+keypoints:
+- "CMake is a build system generator"
+---
+
+Building code is hard. You need long commands to build each part of your code; and you need do to this on many parts of your code.
+
+So people came up with **Build Systems**; these had ways set up dependencies (such as file A needs to be built to build file B), and ways to store the commands used to build each file or type of file. These are language independent (mostly), allowing you to setup builds of almost anything; you can use `make` to build LaTeX documents if you wish. Some common build systems include make (the classic pervasive one), ninja (a newer one from Google designed in the age of build system generators), and rake (Ruby make, nice syntax for Ruby users).
+
+However, this is:
+
+* Mostly hand coded: You have to know all the proper commands
+* Platform/compiler dependent: You have to build the commands for each compiler.
+* Not aware of dependencies: If you require a library, you have to handle the paths, etc.
+* Hard to extend; if you want to use an IDE instead, good luck.
+
+Enter **Build System Generators** (hereby labeled BSGs for brevity). These understand the concepts of your programming language build; they usually support common compilers, languages, libraries, and output formats. These usually write a build system (or IDE) file and then let that do the actually build. The most popular BSG is CMake, which stands for Cross-platform Make. But as we've just shown, it is not really in the same category as make. Other BSGs include Meson (by Google), SCons (older Python system), Meson (very young Python system), and a few others. But CMake has unparalleled support by IDEs, libraries, and compilers.
+
+Note that both CMake and Make are custom languages rather than being built in an existing language, like rake and SCons, etc. While it is nice to consolidate languages, the requirement that you have an external language installed and configured was too high for any of these to catch on for general use.
+
+To recap, you should use CMake if:
+
+* You want to avoid hard-coding paths
+* You need to build a package on more than one computer
+* You want to use CI (continuous integration)
+* You need to support different OSs (maybe even just flavors of Unix)
+* You want to support multiple compilers
+* You want to use an IDE, but maybe not all of the time
+* You want to describe how your program is structured logically, not flags and commands
+* You want to use a library
+* You want to use tools, like Clang-Tidy, to help you code
+* You want to use a debugger
+
+
+## (More) Modern CMake
+
+CMake has really changed dramatically since it was introduced around 2000. And, by the time of 2.8, it was available in lots of Linux Distribution package managers. However, this means there often are really old versions of CMake "available by default" in your environment. Please, please upgrade and design for newer CMake. No one likes writing or debugging build systems[^1]. Using a newer version can cut your build system code in less than half, reduce bugs, integrate better with external dependants, and more. Installing CMake can be as little as one line, and doesn't require sudo access. [See more info here](https://cliutils.gitlab.io/modern-cmake/chapters/intro/installing.html).
+
+## Other sources
+
+There are some other places to find good information on the web. Here are some of them:
+
+* [Modern CMake][]: The book this tutorial derives from.
+* [The official help](https://cmake.org/cmake/help/latest/): Really amazing documentation. Nicely organized, great search, and you can toggle versions at the top. It just doesn't have a great "best practices tutorial", which is what this book tries to fill in.
+* [Effective Modern CMake](https://gist.github.com/mbinna/c61dbb39bca0e4fb7d1f73b0d66a4fd1): A great list of do's and don'ts.
+* [Embracing Modern CMake](https://steveire.wordpress.com/2017/11/05/embracing-modern-cmake/): A post with good description of the term
+* [It's time to do CMake Right](https://pabloariasal.github.io/2018/02/19/its-time-to-do-cmake-right/): A nice set of best practices for Modern CMake projects.
+* [The Ultimate Guide to Modern CMake](https://rix0r.nl/blog/2015/08/13/cmake-guide/): A slightly dated post with similar intent.
+* [More Modern CMake](https://youtu.be/y7ndUhdQuU8): A great presentation from Meeting C++ 2018 that recommends CMake 3.12+. This talk makes calls CMake 3.0+ "Modern CMake" and CMake 3.12+ "More Modern CMake".
+* [toeb/moderncmake](https://github.com/toeb/moderncmake): A nice presentation and examples about CMake 3.5+, with intro to syntax through project organization
+
+[Modern CMake]: https://cliutils.gitlab.io/modern-cmake/
+
+{% include links.md %}

--- a/_includes/aio-script.md
+++ b/_includes/aio-script.md
@@ -1,0 +1,38 @@
+{% comment %}
+As a maintainer, you don't need to edit this file.
+If you notice that something doesn't work, please 
+open an issue: https://github.com/carpentries/styles/issues/new
+{% endcomment %}
+
+<script>
+  window.onload = function() {
+    var lesson_episodes = [
+    {% for episode in site.episodes %}
+    "{{ episode.url}}"{% unless forloop.last %},{% endunless %}
+    {% endfor %}
+    ];
+    var xmlHttp = [];  /* Required since we are going to query every episode. */
+    for (i=0; i < lesson_episodes.length; i++) {
+      xmlHttp[i] = new XMLHttpRequest();
+      xmlHttp[i].episode = lesson_episodes[i];  /* To enable use this later. */
+      xmlHttp[i].onreadystatechange = function() {
+        if (this.readyState == 4 && this.status == 200) {
+          var article_here = document.getElementById(this.episode);
+          var parser = new DOMParser();
+          var htmlDoc = parser.parseFromString(this.responseText,"text/html");
+          var htmlDocArticle = htmlDoc.getElementsByTagName("article")[0];
+          article_here.innerHTML = htmlDocArticle.innerHTML;
+        }
+      }
+      var episode_url = "{{ relative_root_path }}" + lesson_episodes[i];
+      xmlHttp[i].open("GET", episode_url);
+      xmlHttp[i].send(null);
+    }
+  }
+</script>
+{% comment %}
+Create an anchor for every episode.
+{% endcomment %}
+{% for episode in site.episodes %}
+<article id="{{ episode.url }}"></article>
+{% endfor %}

--- a/aio.md
+++ b/aio.md
@@ -1,0 +1,13 @@
+---
+permalink: /aio/index.html
+---
+
+{% comment %}
+As a maintainer, you don't need to edit this file.
+If you notice that something doesn't work, please 
+open an issue: https://github.com/carpentries/styles/issues/new
+{% endcomment %}
+
+{% include base_path.html %}
+
+{% include aio-script.md %}

--- a/index.md
+++ b/index.md
@@ -1,5 +1,5 @@
 ---
-layout: workshop      # DON'T CHANGE THIS.
+layout: lesson      # DON'T CHANGE THIS.
 carpentry: "swc"      # what kind of Carpentry (must be either "lc" or "dc" or "swc").  
                       # Be sure to update the Carpentry type in _config.yml as well.  
 venue: "LBNL"         # brief name of host site without address (e.g., "Euphoric State University")
@@ -32,41 +32,29 @@ see the changes take effect locally.
 {% endif %}
 
 
-<h2 id="general">General Information</h2>
 
 Welcome to the FIRST-HEP CMake tutorial! The aim of this tutorial is to cover the basics of using CMake. This tutorial is based on the online book [Modern CMake][], with a focus on CMake 3.11+. This is almost what is [called the "More Modern" era](https://github.com/Bagira80/More-Modern-CMake) of CMake (which is 3.12+). We will cover the basics of making and building a project, and some details of design.
 
-## Lessons
+> ## Prereqs
+> 
+> On your computer, you need to have:
+> 
+> * `git`
+> * `cmake` (Version 3.11 or newer). See the [instructions here][CMake Instructions].
+> * A C++ compiler - system default is fine.
+> * `make` or `ninja`
+> 
+> Note that the ATLAS docker container has all of these things already. A quick and minimal docker works too:
+> 
+> ```bash
+> docker run --rm -it alpine
+> apk add git g++ cmake make
+> ```
+>
+> 
+> This does *not* make a volume, so you will lose whatever you do in here when it exits - that's probably a good thing mostly.
+>
+{: .prereq}
 
-1. [Introduction](01-intro)
-2. [Building with CMake](02-building)
-3. [Your first CMakeLists.txt file](03-cmakelists)
-4. [Targets](04-targets)
-4. [Variables explained](05-variables)
-5. Project Structure
-6. Common problems and solutions
-7. Debugging
-8. Finding packages
-9. ROOT
-10. BONUS: Installing a package
-
-
-## Prereqs
-
-On your computer, you need to have:
-
-* `git`
-* `cmake` (Version 3.11 or newer). See the [instructions here][CMake Instructions].
-* A C++ compiler - system default is fine.
-* `make` or `ninja`
-
-Note that the ATLAS docker container has all of these things already. A quick and minimal docker works too:
-
-```bash
-docker run --rm -it alpine
-apk add git g++ cmake make
-```
-
-This does *not* make a volume, so you will lose whatever you do in here when it exits - that's probably a good thing mostly.
 
 {% include links.md %}

--- a/reference.md
+++ b/reference.md
@@ -1,0 +1,9 @@
+---
+layout: reference
+---
+
+## Glossary
+
+FIXME
+
+{% include links.md %}

--- a/setup.md
+++ b/setup.md
@@ -1,0 +1,25 @@
+---
+title: Pre-workshop Material
+---
+
+Before working through the tutorial, please be diligent and read through this page and ensure you
+are familiar with all of these computing skills.  They are essential for any HEP physicist
+and will benefit you throughout your career.  However, if you are pressed for time in the next days
+then **be sure to install and familiarize yourself with Docker**.
+
+
+## Install This Now! : [Docker](https://www.docker.com/)
+
+  <p>
+    <a href="https://www.docker.com/">Docker</a> is a powerful tool that allows you
+    to perform a virtualization of your environment but completely in software.  It
+    allows you to bundle up the installation of tools for use by others in a uniform way
+    and we will be using it throughout this bootcamp.  Installing docker is absolutely
+    necessary and there are directions to do this in each operating system.  For those
+    of you that are using a Windows operating system, if you already have docker running
+    and are comfortable using it, that is fine.  However, if you do not, then be aware
+    that its usage on Windows can be challenging and none of the tutors know how to use
+    such a setup.  Therefore, <strong>we highly reccomend that you reconsider
+    your decision to use the Windows operating system as a high energy physicist.</strong>
+  </p>
+


### PR DESCRIPTION
This took a bit more than changing one line, but the format of the content now compiles into a SWC "lesson" style instead of a workshop template.  I had to add a number of files, and I modified your front page, but added the necessary _episodes such that the schedule stays the same.  There is also now a "setup.md" section, which can be removed or you could consider moving the prerequisites there.  It's up to you, of course.

Let me know if you have any questions.